### PR TITLE
Enable sharing of release URLs via Facebook with proper meta info.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -12,11 +12,11 @@
     RewriteRule ^$ /release/%1 [QSD,R=301,L]
 
     # rewrite app urls
-    RewriteRule  ^about$             home.php?/$1 [NC,L]
+    RewriteRule  ^about$             index.html?/$1 [NC,L]
     RewriteRule  ^release/(.*)$      home.php?/$1 [NC,L]
-    RewriteRule  ^tag/(.*)$          home.php?/$1 [NC,L]
-    RewriteRule  ^blog$              home.php?/$1 [NC,L]
-    RewriteRule  ^blog/(.*)$         home.php?/$1 [NC,L]
+    RewriteRule  ^tag/(.*)$          index.html?/$1 [NC,L]
+    RewriteRule  ^blog$              index.html?/$1 [NC,L]
+    RewriteRule  ^blog/(.*)$         index.html?/$1 [NC,L]
 
 
 </IfModule>

--- a/.htaccess
+++ b/.htaccess
@@ -12,11 +12,11 @@
     RewriteRule ^$ /release/%1 [QSD,R=301,L]
 
     # rewrite app urls
-    RewriteRule  ^about$             index.html?/$1 [NC,L]
-    RewriteRule  ^release/(.*)$      index.html?/$1 [NC,L]
-    RewriteRule  ^tag/(.*)$          index.html?/$1 [NC,L]
-    RewriteRule  ^blog$              index.html?/$1 [NC,L]
-    RewriteRule  ^blog/(.*)$         index.html?/$1 [NC,L]
+    RewriteRule  ^about$             home.php?/$1 [NC,L]
+    RewriteRule  ^release/(.*)$      home.php?/$1 [NC,L]
+    RewriteRule  ^tag/(.*)$          home.php?/$1 [NC,L]
+    RewriteRule  ^blog$              home.php?/$1 [NC,L]
+    RewriteRule  ^blog/(.*)$         home.php?/$1 [NC,L]
 
 
 </IfModule>

--- a/home.php
+++ b/home.php
@@ -1,0 +1,71 @@
+<?php
+
+
+$index = file_get_contents('index.html');
+$path = realpath(dirname( __FILE__ ));
+
+/*
+
+{
+    "cat": "enrmp001",
+    "artist": "ps",
+    "album": "from my own little corner",
+    "release_date": "2002-01-14",
+    "info_en": "3 track dark ambient ep from our staff member <a href=\"http:\/\/tpolm.org\/~ps\/\">ps<\/a>. Photo artwork by Joana Queir\u00f3z.",
+    "info_pt": "EP de dark ambient de 3 temas feito pelo nosso membro de staff <a href=\"http:\/\/tpolm.org\/~ps\/\">ps<\/a>. Fotografia de Joana Queir\u00f3z.",
+    "discogs": "http:\/\/www.discogs.com\/ps-From-My-Own-Little-Corner\/release\/606784",
+    "jamendo": null,
+    "sonicsquirrel": null,
+    "scene_org": "http:\/\/scene.org\/file.php?file=%2Fmusic%2Fgroups%2Fenough_records%2Fenrmp001_ps_-_from_my_own_little_corner.zip&fileinfo",
+    "bandcamp": "http:\/\/enoughrec.bandcamp.com\/album\/from-my-own-little-corner",
+    "soundcloud": null,
+    "itunes": null,
+    "spotify": null,
+    "mixcloud": null,
+    "fma": null,
+    "rym": "http:\/\/rateyourmusic.com\/release\/ep\/ps_f1\/from_my_own_little_corner\/",
+    "musicbrainz": null,
+    "dogmazic": null,
+    "lastfm": "http:\/\/www.last.fm\/music\/ps\/from+my+own+little+corner",
+    "tags": ["laidback", "dark", "ambient", ".pt"],
+    "archiveorg": "http:\/\/www.archive.org\/details\/enrmp001_ps_-_from_my_own_little_corner",
+    "cover": "http:\/\/enoughrecords.scene.org\/covers\/enrmp001.jpg",
+    "cc": "http:\/\/creativecommons.org\/licenses\/by-nc-sa\/3.0\/",
+    "cc_img": "ccbyncsa.png",
+    "tracks": ["http:\/\/http.de.scene.org\/pub\/music\/groups\/enough_records\/enrmp001_ps_-_from_my_own_little_corner\/01_ps_-_lost_in_familiar_alleys.mp3", "http:\/\/http.de.scene.org\/pub\/music\/groups\/enough_records\/enrmp001_ps_-_from_my_own_little_corner\/02_ps_-_while_she_is_not_here.mp3", "http:\/\/http.de.scene.org\/pub\/music\/groups\/enough_records\/enrmp001_ps_-_from_my_own_little_corner\/03_xhale_vs_ps_-_two_seconds_of_time.mp3"]
+}
+
+*/
+
+
+
+if (strpos(strtolower($_SERVER['HTTP_USER_AGENT']), 'facebook') !== false) {
+    $json = file_get_contents($path."/data/all.json");
+    $releases = json_decode($json,true);
+    // print_r($releases);
+
+    // is probably a FB robot, looking for content
+    // search for enrmp001
+    $data = false;
+
+    $segments = explode('/', $_SERVER['REQUEST_URI']);
+    $cat = $segments[2];
+
+    foreach ($releases as $k => $v) {
+        if ($v['cat'] === $cat) {
+            $data = $v;
+            $data['info_en'] = strip_tags($data['info_en']);
+            $data['url'] = 'http://enoughrecords.scene.org/release/'.$cat;
+        }
+    }
+
+    if ($data) {
+        include_once($path.'/robot.php');
+    } else  {
+        echo $index;
+    }
+
+    
+} else {
+    echo $index;
+}

--- a/robot.php
+++ b/robot.php
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+    <head>
+        <title><?php echo $data['album'].' - '.$data['artist'] ?></title>
+        <meta name="description" content="<?php echo $data['cat'].' - '.$data['info_en'] ?>" />
+        <meta property="og:title" content="<?php echo $data['album'] ?>" />
+        <meta property="og:description" content="<?php echo $data['info_en'] ?>" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="<?php echo $data['url'] ?>" />
+        <meta property="og:image" content="<?php echo $data['cover'] ?>" />
+        <link rel="image_src" href="<?php echo $data['cover'] ?>">
+    </head>
+    <body>
+       <?php
+
+        echo $data['info_en']; 
+        ?>
+    </body>
+</html>

--- a/robot.php
+++ b/robot.php
@@ -3,8 +3,8 @@
     <head>
         <title><?php echo $data['album'].' - '.$data['artist'] ?></title>
         <meta name="description" content="<?php echo $data['cat'].' - '.$data['info_en'] ?>" />
-        <meta property="og:title" content="<?php echo $data['album'] ?>" />
-        <meta property="og:description" content="<?php echo $data['info_en'] ?>" />
+        <meta property="og:title" content="<?php echo $data['album'].' - '.$data['artist'] ?>" />
+        <meta property="og:description" content="<?php echo $data['cat'].' - '.$data['info_en'] ?>" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="<?php echo $data['url'] ?>" />
         <meta property="og:image" content="<?php echo $data['cover'] ?>" />


### PR DESCRIPTION
Fixes https://github.com/enoughrec/arecordlabel/issues/20 (at least for facebook!)

Looking like:

![screen shot 2015-02-01 at 17 43 22](https://cloud.githubusercontent.com/assets/201036/5992831/e271348a-aa39-11e4-8b0f-3481f30ccfcf.png)
![screen shot 2015-02-01 at 17 44 36](https://cloud.githubusercontent.com/assets/201036/5992837/02ed906e-aa3a-11e4-810b-e5453dd1c50f.png)
